### PR TITLE
Loading Icons for Async Requests in Selects

### DIFF
--- a/src/components/BattleTracker.vue
+++ b/src/components/BattleTracker.vue
@@ -16,7 +16,7 @@ const { battleHistory } = storeToRefs(historyStore)
 const { selectedRegion, selectedLocation, selectedPokemon } =
   storeToRefs(selectionsStore)
 
-// Location PI
+// Location API
 const locationAPI = new LocationClient({
   cacheOptions: { maxAge: 10000, exclude: { query: false } },
 })

--- a/src/components/BattleTracker.vue
+++ b/src/components/BattleTracker.vue
@@ -2,7 +2,7 @@
 import { computedAsync } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { LocationClient, Name, PokemonStat } from 'pokenode-ts'
-import { computed, ref } from 'vue'
+import { computed, reactive, ref, watch } from 'vue'
 import { useHistoryStore } from '../stores/history'
 import { useSelectionsStore } from '../stores/selections'
 import { BattleHistory } from '../types'
@@ -16,7 +16,7 @@ const { battleHistory } = storeToRefs(historyStore)
 const { selectedRegion, selectedLocation, selectedPokemon } =
   storeToRefs(selectionsStore)
 
-// API
+// Location PI
 const locationAPI = new LocationClient({
   cacheOptions: { maxAge: 10000, exclude: { query: false } },
 })
@@ -32,6 +32,7 @@ const relevantStats = (stats: PokemonStat[]) => {
 
 const regionList = ref<string[]>(regions)
 
+// turns the region list into options digestable by the searchable dropdown
 const regionListOptions = computed(() => {
   return regionList.value.map((region) => {
     return {
@@ -53,8 +54,6 @@ const areaList = computedAsync(async () => {
     )
   else return []
 }, [])
-
-// POKEMON API
 
 // has only a list of the pokemon names
 const pokemonList = computedAsync(async () => {
@@ -123,20 +122,53 @@ const processStatString = (hist: BattleHistory) => {
     (hist.config.pokerus ? ' and with Pokérus' : '')
   )
 }
+
+const submitToAddToHistory = async () => {
+  loading.isLoadingAddHistory = true
+  await historyStore.addToHistory()
+  loading.isLoadingAddHistory = false
+}
+
+// loading logic
+
+watch(selectedRegion, (newR) => {
+  loading.isLoadingArea = newR.code !== ''
+  selectedLocation.value = { label: '', code: '' }
+  selectedPokemon.value = { label: '', code: '' }
+})
+
+watch(areaList, () => {
+  loading.isLoadingArea = false
+})
+
+watch(selectedLocation, (newLoc) => {
+  loading.isLoadingPokemon = newLoc.code !== ''
+  selectedPokemon.value = { label: '', code: '' }
+})
+
+watch(pokemonList, () => {
+  loading.isLoadingPokemon = false
+})
+
+const loading = reactive({
+  isLoadingArea: false,
+  isLoadingPokemon: false,
+  isLoadingAddHistory: false,
+})
 </script>
 
 <template>
-  <form class="mb-4" @submit.prevent="historyStore.addToHistory">
+  <form class="mb-4" @submit.prevent="submitToAddToHistory">
     <label class="label">
       <span class="label-text">Region</span>
     </label>
     <v-select v-model="selectedRegion" :options="regionListOptions"></v-select>
     <label class="label">
       <span class="label-text">Area</span>
-      <!-- <svg
+      <svg
         v-if="loading.isLoadingArea"
         xmlns="http://www.w3.org/2000/svg"
-        class="h-5 w-5"
+        class="animate-spin h-5 w-5"
         viewBox="0 0 20 20"
         fill="currentColor"
       >
@@ -145,16 +177,42 @@ const processStatString = (hist: BattleHistory) => {
           d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z"
           clip-rule="evenodd"
         />
-      </svg> -->
+      </svg>
     </label>
-    <v-select v-model="selectedLocation" :options="areaList"></v-select>
+    <v-select
+      v-model="selectedLocation"
+      :options="areaList"
+      :disabled="areaList.length === 0"
+    ></v-select>
     <label class="label">
       <span class="label-text">Pokémon</span>
+      <svg
+        v-if="loading.isLoadingPokemon"
+        xmlns="http://www.w3.org/2000/svg"
+        class="animate-spin h-5 w-5"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+      >
+        <path
+          fill-rule="evenodd"
+          d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z"
+          clip-rule="evenodd"
+        />
+      </svg>
     </label>
-    <v-select v-model="selectedPokemon" :options="pokemonNamesList"></v-select>
-    <button type="submit" class="btn btn-primary">
-      <!--       :class="{ loading: loading.isLoadingAddHistory }"
- -->
+    <v-select
+      v-model="selectedPokemon"
+      :options="pokemonNamesList"
+      :disabled="pokemonList.length === 0"
+    ></v-select>
+    <button
+      type="submit"
+      class="btn btn-primary"
+      :class="{
+        loading: loading.isLoadingAddHistory,
+        'btn-disabled': selectedPokemon.code === '',
+      }"
+    >
       Defeated
     </button>
   </form>

--- a/src/components/StatEditor.vue
+++ b/src/components/StatEditor.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { storeToRefs } from 'pinia'
+import { ref, watch } from 'vue'
 import { useSelectionsStore } from '../stores/selections'
 import { useStatsStore } from '../stores/stats'
 import { StatEditorProps } from '../types'
@@ -11,10 +13,15 @@ const statsStore = useStatsStore()
 
 // need to subscribe to a state here to make sure effectText is properly updated
 const selectionStore = useSelectionsStore()
+const { selectedItem } = storeToRefs(selectionStore)
+
+const loadingEffectText = ref(false)
 
 // TODO: fix this logic
-selectionStore.$subscribe(() => {
-  selectionStore.getEffectText()
+watch(selectedItem, async (newSI) => {
+  loadingEffectText.value = newSI !== ''
+  await selectionStore.getEffectText()
+  loadingEffectText.value = false
 })
 </script>
 
@@ -31,12 +38,25 @@ selectionStore.$subscribe(() => {
   <label class="label">
     <span class="label-text">Held item</span>
   </label>
-  <select v-model="selectionStore.selectedItem" class="select select-bordered">
+  <select v-model="selectedItem" class="select select-bordered">
     <option selected value="">No item</option>
     <option v-for="item in evItems" :key="item.id" :value="item.name">
       {{ item.names.filter((n) => n.language.name === 'en')[0].name }}
     </option>
   </select>
+  <svg
+    v-if="loadingEffectText"
+    xmlns="http://www.w3.org/2000/svg"
+    class="animate-spin h-5 w-5 inline"
+    viewBox="0 0 20 20"
+    fill="currentColor"
+  >
+    <path
+      fill-rule="evenodd"
+      d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z"
+      clip-rule="evenodd"
+    />
+  </svg>
   {{ selectionStore.effectText }}
   <div class="form-control">
     <label class="label cursor-pointer">

--- a/src/stores/history.ts
+++ b/src/stores/history.ts
@@ -47,8 +47,7 @@ export const useHistoryStore = defineStore('history', {
       const { selectedPokemon, selectedItem, effectText, pokerus } =
         storeToRefs(selectionsStore)
 
-      // loading.isLoadingAddHistory = true
-      if (selectedPokemon.value !== undefined) {
+      if (selectedPokemon.value.code) {
         const stats = await getStats(selectedPokemon.value.code)
         const hist = {
           stats: stats,
@@ -65,7 +64,6 @@ export const useHistoryStore = defineStore('history', {
           statsStore.changeStatEV(key, value)
         })
       }
-      // loading.isLoadingAddHistory = falsex
     },
     deleteHistoryEntry(hist: BattleHistory) {
       const statsStore = useStatsStore()


### PR DESCRIPTION
This PR adds loading icons (from [Hero Icons](https://heroicons.com/)) to select components that call an API asynchronously. Once the request finishes, the loading disappears. Some selects which rely on the changed select have been disabled to reflect that the state is not currently finished (or, more specifically, that the list is empty). This is to provide feedback to the user that a change has occurred when making a selection, and that the user should be waiting for something.